### PR TITLE
fix: Resolve 4 CodeQL alerts

### DIFF
--- a/.github/workflows/security-fix.yml
+++ b/.github/workflows/security-fix.yml
@@ -69,7 +69,7 @@ jobs:
           python-version: '3.12'
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
       - name: Get Dependabot alerts
         id: alerts

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -78,7 +78,8 @@ program
       
     } catch (error) {
       spinner.fail('Failed to start');
-      console.error(chalk.red(error.message));
+      console.error(chalk.red('Failed to start git-steer. Check your credentials and try again.'));
+      if (process.env.DEBUG) console.error(error);
       process.exit(1);
     }
   });
@@ -92,7 +93,8 @@ program
       const steer = new GitSteer({ keychain });
       await steer.showStatus();
     } catch (error) {
-      console.error(chalk.red(`Error: ${error.message}`));
+      console.error(chalk.red('Failed to retrieve status. Check your credentials and try again.'));
+      if (process.env.DEBUG) console.error(error);
       process.exit(1);
     }
   });
@@ -110,7 +112,8 @@ program
       spinner.succeed('State synced');
     } catch (error) {
       spinner.fail('Sync failed');
-      console.error(chalk.red(error.message));
+      console.error(chalk.red('Failed to sync state. Check your credentials and try again.'));
+      if (process.env.DEBUG) console.error(error);
       process.exit(1);
     }
   });


### PR DESCRIPTION
## Summary
- Fix 3 **clear-text logging of sensitive information** alerts in `bin/cli.js` (High)
- Fix 1 **unpinned tag for non-immutable Action** in `security-fix.yml` (Medium)

## Changes
- Replace raw `error.message` logging with generic user-facing messages
- Add `DEBUG` env var support: run with `DEBUG=1 git-steer ...` for verbose errors
- Pin `astral-sh/setup-uv` to commit SHA `38f3f104`

## CodeQL Alerts Resolved
| Alert | Severity | File | Line |
|-------|----------|------|------|
| Clear-text logging of sensitive information | **High** | bin/cli.js | :81 |
| Clear-text logging of sensitive information | **High** | bin/cli.js | :95 |
| Clear-text logging of sensitive information | **High** | bin/cli.js | :113 |
| Unpinned tag for non-immutable Action | Medium | security-fix.yml | :72 |

## Test plan
- [ ] Verify `git-steer start` shows generic error on failure
- [ ] Verify `DEBUG=1 git-steer start` shows full error details
- [ ] Confirm workflow still runs with pinned action SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 4 CodeQL alerts (3 high, 1 medium) by removing clear-text error logging in the CLI and pinning a GitHub Action. Adds an opt-in DEBUG mode for troubleshooting without exposing sensitive info by default.

- **Bug Fixes**
  - Replace raw error.message with generic errors in start, status, and sync commands.
  - Support DEBUG=1 to print full errors when needed.

- **Dependencies**
  - Pin astral-sh/setup-uv to commit 38f3f104 in the security-fix workflow.

<sup>Written for commit 4adcdd88ee67fc0f06661377358ae0d7095e55cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CLI error messages with clearer guidance when operations fail. Full error details now available when DEBUG mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->