### PR TITLE
ci: pin checkout, setup-node, upload-artifact to commit SHA

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -32,10 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 
@@ -124,7 +124,7 @@ jobs:
           fi
 
       - name: Upload scan artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cve-scan-results
           path: |


### PR DESCRIPTION
## git-steer: Pin GitHub Actions to commit SHAs

Pins unpinned `uses:` references to their full commit SHA to prevent supply-chain attacks.

### Changes
**.github/workflows/cve-scan.yml**
- `actions/checkout@v4` → `@34e1148...`
- `actions/setup-node@v4` → `@49933ea...`
- `actions/upload-artifact@v4` → `@ea165f8...`

> Auto-generated by git-steer freshness detector