### PR TITLE
fix(ci): pin lock-regen.yml actions to SHAs

### DIFF
--- a/.github/workflows/lock-regen.yml
+++ b/.github/workflows/lock-regen.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Generate token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.GIT_STEER_APP_ID }}
           private-key: ${{ secrets.GIT_STEER_PRIVATE_KEY }}
@@ -42,7 +42,7 @@ jobs:
           repositories: ${{ steps.parse.outputs.repo }}
 
       - name: Checkout target repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: ${{ inputs.target_repo }}
           token: ${{ steps.app-token.outputs.token }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: Setup Python + uv
         if: contains(inputs.ecosystems, 'uv')
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
         with:
           python-version: '3.12'
 
@@ -60,7 +60,7 @@ jobs:
 
       - name: Setup Node.js
         if: contains(inputs.ecosystems, 'npm')
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 


### PR DESCRIPTION
Repo requires SHA-pinned actions; lock-regen still had @v* tags so dispatch failed at Set up job. Pinned all four.