### PR TITLE
fix(ci): repair heartbeat build + dedicated changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,36 @@
+name: Changelog Sync
+
+# Autonomous changelog: scans managed repos for recent merged PRs + releases and
+# commits changelog entries to the blog (ChangelogTimeline on ry-ops.dev). Runs on
+# its own — ci-changelog.mjs only needs octokit, so we install it in isolation and
+# DON'T run git-steer's full build (which depends on private @git-fabric/* packages).
+
+on:
+  schedule:
+    - cron: '0 7 * * *'   # daily, 1h after the heartbeat
+  workflow_dispatch: {}
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+        with:
+          node-version: '20'
+
+      - name: Sync changelog to fabric-forge/blog
+        env:
+          # GIT_FABRIC_PAT reads ry-ops PRs/state AND writes the fabric-forge/blog deploy repo.
+          GH_TOKEN: ${{ secrets.GIT_FABRIC_PAT }}
+          STATE_OWNER: ry-ops
+          STATE_REPO: git-steer-state
+          BLOG_OWNER: fabric-forge   # live ry-ops.dev deploy source (Pages blog-5f3)
+          BLOG_REPO: blog
+        run: |
+          # Isolated octokit install — avoids git-steer's private @git-fabric build deps.
+          tmp="$(mktemp -d)"
+          ( cd "$tmp" && npm init -y -q && npm install octokit@^4 --no-audit --no-fund )
+          cp scripts/ci-changelog.mjs "$tmp/ci-changelog.mjs"
+          ( cd "$tmp" && node ci-changelog.mjs )

--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -33,6 +33,13 @@ jobs:
         with:
           node-version: '20'
 
+      # Private @git-fabric/* deps resolve to ssh URLs; rewrite to HTTPS-with-token
+      # so npm install can fetch them on the runner (no SSH key needed).
+      - name: Configure git auth for private deps
+        run: |
+          git config --global url."https://x-access-token:${{ secrets.GIT_FABRIC_PAT }}@github.com/".insteadOf "ssh://git@github.com/"
+          git config --global --add url."https://x-access-token:${{ secrets.GIT_FABRIC_PAT }}@github.com/".insteadOf "git@github.com:"
+
       - name: Install dependencies and build
         run: npm install --no-audit --no-fund && npm run build
 
@@ -184,17 +191,8 @@ jobs:
           STATE_REPO: git-steer-state
         run: node scripts/ci-dashboard.mjs
 
-      - name: Sync changelog to blog
-        if: inputs.task == 'security-scan' || inputs.task == '' || inputs.task == 'full-audit' || inputs.task == 'changelog-sync'
-        env:
-          # GIT_FABRIC_PAT spans both orgs: reads ry-ops PRs/state AND writes fabric-forge/blog.
-          # (The ry-ops App token can read ry-ops but cannot write the fabric-forge deploy repo.)
-          GH_TOKEN: ${{ secrets.GIT_FABRIC_PAT }}
-          STATE_OWNER: ry-ops
-          STATE_REPO: git-steer-state
-          BLOG_OWNER: fabric-forge   # live ry-ops.dev deploy source (Pages blog-5f3); ry-ops/blog is a stale mirror
-          BLOG_REPO: blog
-        run: node scripts/ci-changelog.mjs
+      # NOTE: changelog sync moved to its own workflow (.github/workflows/changelog.yml)
+      # so it runs reliably without depending on this heartbeat's full build.
 
       - name: Log heartbeat to state
         if: always()


### PR DESCRIPTION
A: git-config rewrite so npm fetches private @git-fabric deps (fixes the heartbeat). B: dedicated changelog.yml → fabric-forge/blog.