### PR TITLE
fix(ci): make security-fix-worker fix step resilient

### DIFF
--- a/.github/workflows/security-fix-worker.yml
+++ b/.github/workflows/security-fix-worker.yml
@@ -128,6 +128,10 @@ jobs:
           HAS_PIP: ${{ steps.alerts.outputs.has_pip }}
           HAS_GOMOD: ${{ steps.alerts.outputs.has_gomod }}
         run: |
+          # Fixes are best-effort: a non-zero from a background fix subshell
+          # must NOT fail the step (the default `bash -e` + `wait $PID` would).
+          # The "Check for changes" step + the ADR-005 gate are the real gates.
+          set +e
           # Fix npm in background
           if [ "$HAS_NPM" = "true" ]; then
             (

--- a/.github/workflows/security-fix-worker.yml
+++ b/.github/workflows/security-fix-worker.yml
@@ -193,6 +193,9 @@ jobs:
           [ -n "${NPM_PID:-}" ] && wait "$NPM_PID"
           [ -n "${PIP_PID:-}" ] && wait "$PIP_PID"
           [ -n "${GOMOD_PID:-}" ] && wait "$GOMOD_PID"
+          # Best-effort step: always exit 0 (the last `[ -n ... ] && wait` can be
+          # false when an ecosystem is absent, which would otherwise fail the step).
+          exit 0
 
       - name: Check for changes
         id: changes


### PR DESCRIPTION
Fix step crashed fleet-wide (bash -e + wait propagation, and a falsy final line). set +e + exit 0. Needed for the fleet remediation sweep.