### PR TITLE
fix(dashboard): parse managed-repos.yaml as real YAML, not regex

### DIFF
--- a/scripts/ci-dashboard.mjs
+++ b/scripts/ci-dashboard.mjs
@@ -13,6 +13,7 @@
  */
 
 import { Octokit } from 'octokit';
+import { parse as parseYaml } from 'yaml';
 import { generateDashboardHtml } from '../dist/dashboard/templates.js';
 
 const token = process.env.GH_TOKEN;
@@ -34,14 +35,26 @@ async function getManagedRepos() {
       { owner: STATE_OWNER, repo: STATE_REPO, path: 'config/managed-repos.yaml' }
     );
     const content = Buffer.from(data.content, 'base64').toString('utf8');
-    const repos = content.match(/^\s*-\s+(.+)$/gm);
-    if (repos) {
-      return repos.map((r) => {
-        const name = r.replace(/^\s*-\s+/, '').trim();
-        const [owner, repo] = name.split('/');
-        return { owner, name: repo, fullName: name };
-      });
-    }
+    // managed-repos.yaml is `repos: [{ owner, name, policies }]`. Parse it as
+    // real YAML — the old `/^\s*-\s+(.+)$/` regex captured `owner: ry-ops` off
+    // every entry, collapsing the whole fleet to one bogus name so the scan saw
+    // zero alerts everywhere (falsely-clean dashboard). Mirrors the #77 fix to
+    // heartbeat.yml. Also tolerates a legacy flat `- owner/name` list.
+    const doc = parseYaml(content) || {};
+    const entries = Array.isArray(doc) ? doc : (doc.repos || []);
+    const repos = entries
+      .map((r) => {
+        if (typeof r === 'string') {
+          const [owner, name] = r.split('/');
+          return owner && name ? { owner, name, fullName: `${owner}/${name}` } : null;
+        }
+        if (r && r.owner && r.name) {
+          return { owner: r.owner, name: r.name, fullName: `${r.owner}/${r.name}` };
+        }
+        return null;
+      })
+      .filter(Boolean);
+    if (repos.length > 0) return repos;
   } catch {
     // fallback
   }


### PR DESCRIPTION
## The bug (fleet-wide observability failure)

`ci-dashboard.mjs` `getManagedRepos()` parsed `config/managed-repos.yaml` with `/^\s*-\s+(.+)$/`. The file's actual schema is:

```yaml
repos:
  - owner: ry-ops
    name: DriveIQ
    policies: []
```

So the regex captured **`owner: ry-ops`** off every entry, collapsing all 43 managed repos to a single bogus name. The scan then queried garbage repo names, every request errored, and the dashboard reported **0 open alerts across the entire fleet → `fixRate: 1.0`**.

This is the same class of bug #77 fixed in `heartbeat.yml` — but `ci-dashboard.mjs` was never updated. It silently made the public dashboard (and the new `status.json`) report a falsely-clean fleet, masking real CVE backlog on every repo.

## Surfaced by

The `status.json` emitter (PR #78) reported `totalOpenAlerts: 0` / `fixRate: 1.0` while simultaneously listing 4 repos in `escalation.hardStop` (incl. DriveIQ, which has 71 open Dependabot alerts). The escalation list comes from persisted state and is real; the scan was blind.

## Fix

Parse with the `yaml` package (already a direct dep, `^2.3.0`) and map `owner`/`name` pairs. Tolerates a legacy flat `- owner/name` list for safety.

**Verified:** now yields **43 unique repos** including `ry-ops/DriveIQ` (was 1 malformed entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)