### PR TITLE
feat(security): autonomous no-fix VEX + documenting PR

### DIFF
--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -173,6 +173,16 @@ jobs:
           done <<< "${{ steps.repos.outputs.repos }}"
           echo "Escalation ladder run on $ESCALATED repo(s) with open alerts."
 
+      # ADR-004 C-004-003: alerts with NO upstream fix can't be bumped, so the
+      # worker skips them. Track them as OpenVEX `under_investigation` in
+      # git-steer-state AND commit a documenting OpenVEX artifact to each
+      # affected repo via PR — so a no-fix advisory is visible, not silent.
+      - name: VEX no-fix advisories
+        if: inputs.task == 'security-scan' || inputs.task == '' || inputs.task == 'full-audit'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: node scripts/vex-no-fix.mjs || echo "  (vex-no-fix error — non-fatal)"
+
       - name: Follow up on security PRs
         if: inputs.task == 'security-scan' || inputs.task == '' || inputs.task == 'full-audit'
         env:

--- a/scripts/vex-no-fix.mjs
+++ b/scripts/vex-no-fix.mjs
@@ -1,31 +1,46 @@
 /**
  * VEX alerts that have no fix available — OpenVEX-compliant (ADR-004 C-004-003).
  *
- * 1. Fetches ALL open Dependabot alerts across repos (fully paginated)
- * 2. Identifies alerts where no patched version exists
- * 3. Writes canonical VEX entries (status "under_investigation", linked to the
- *    component PURL) into the git-steer-state `_vex` store — the SAME shape and
- *    validator the MCP/web stores use (imported from dist/core/vex.js)
+ * Daily-autonomous (wired into the heartbeat). For every managed repo:
+ *   1. Fetch ALL open Dependabot alerts (paginated).
+ *   2. Identify alerts where no patched version exists.
+ *   3. Record canonical VEX `under_investigation` entries in the git-steer-state
+ *      `_vex` store + vex.jsonl ledger (the SAME shape/validator the MCP/web
+ *      stores use), AND
+ *   4. Open/refresh a documenting PR in the TARGET repo that commits an OpenVEX
+ *      document at `.well-known/openvex/no-fix.openvex.json` — a visible,
+ *      machine-consumable artifact stating that no fix is currently available.
+ *      Doc-only, so it's merged directly (no functional-integrity gate needed).
  *
- * "under_investigation" is the honest automated state for a no-fix finding: it
+ * `under_investigation` is the honest automated state for a no-fix finding: it
  * is tracked, not ignored, and the heartbeat re-evaluates it (C-004-005). A
- * human/agent later promotes it to not_affected (+justification) or affected
+ * maintainer later promotes it to not_affected (+justification) or affected
  * (+action_statement) via the vex_set MCP tool or the web API.
  *
+ * Dual auth: GH_TOKEN in CI (heartbeat), macOS Keychain (keytar) locally.
  * Build first: `npm run build` (imports compiled dist/core/vex.js).
  */
 
-import keytar from 'keytar';
-import { App } from 'octokit';
-import { validateVexInput, vexId, makeVexLedgerEntry } from '../dist/core/vex.js';
+import { App, Octokit } from 'octokit';
+import { validateVexInput, vexId, makeVexLedgerEntry, toOpenVex } from '../dist/core/vex.js';
 import { appendJsonl } from './lib/state-jsonl.mjs';
 
-const appId = await keytar.getPassword('git-steer', 'git-steer-app-id');
-const privateKey = await keytar.getPassword('git-steer', 'git-steer-private-key');
-const installationId = await keytar.getPassword('git-steer', 'git-steer-installation-id');
+const STATE_REPO = 'git-steer-state';
+const VEX_PATH = '.well-known/openvex/no-fix.openvex.json';
+const VEX_BRANCH = 'security/vex-no-fix';
 
-const app = new App({ appId, privateKey });
-const octokit = await app.getInstallationOctokit(Number(installationId));
+// ── Dual auth ─────────────────────────────────────────────────────────
+let octokit;
+if (process.env.GH_TOKEN) {
+  octokit = new Octokit({ auth: process.env.GH_TOKEN });
+} else {
+  const keytar = (await import('keytar')).default;
+  const appId = await keytar.getPassword('git-steer', 'git-steer-app-id');
+  const privateKey = await keytar.getPassword('git-steer', 'git-steer-private-key');
+  const installationId = await keytar.getPassword('git-steer', 'git-steer-installation-id');
+  const app = new App({ appId, privateKey });
+  octokit = await app.getInstallationOctokit(Number(installationId));
+}
 
 // ── PURL for SBOM linkage (C-004-004) ─────────────────────────────────
 const PURL_TYPE = { npm: 'npm', pip: 'pypi', go: 'golang', gomod: 'golang', maven: 'maven', nuget: 'nuget', rubygems: 'gem', composer: 'composer', rust: 'cargo', cargo: 'cargo' };
@@ -78,7 +93,6 @@ if (noFixAlerts.length === 0) {
 }
 
 // ── 3. Load existing _vex from git-steer-state ────────────────────────
-const STATE_REPO = 'git-steer-state';
 const owner = repos[0].owner.login;
 
 let cacheJson = {};
@@ -125,7 +139,7 @@ for (const alert of noFixAlerts) {
 cacheJson._vex = existingVex;
 console.log(`VEX entries created: ${newVexCount} new (${Object.keys(existingVex).length} total in state)\n`);
 
-// ── 5. Persist ────────────────────────────────────────────────────────
+// ── 5. Persist state ──────────────────────────────────────────────────
 const content = Buffer.from(JSON.stringify(cacheJson, null, 2)).toString('base64');
 await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
   owner, repo: STATE_REPO, path: 'state/cache.json',
@@ -133,18 +147,107 @@ await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
   content,
   ...(cacheSha ? { sha: cacheSha } : {}),
 });
-
-// Append history rows to the vex.jsonl ledger
 await appendJsonl(octokit, owner, STATE_REPO, 'state/vex.jsonl', ledgerRows);
 console.log(`State saved. (${ledgerRows.length} ledger rows appended)\n`);
 
-// ── 6. Report ─────────────────────────────────────────────────────────
+// ── 6. Open/refresh a documenting PR per affected repo ────────────────
 const byRepo = {};
-for (const a of noFixAlerts) {
-  (byRepo[`${a.owner}/${a.repo}`] ??= []).push(a);
+for (const a of noFixAlerts) (byRepo[`${a.owner}/${a.repo}`] ??= []).push(a);
+
+/** Commit the OpenVEX doc to a branch, open/refresh a PR, and merge it. */
+async function upsertVexDocPr(repoFull, alerts) {
+  const [ro, rn] = repoFull.split('/');
+  // Build the OpenVEX doc from this scan's no-fix set (authoritative "current").
+  const entries = alerts.map((a) => ({
+    cve_id: a.cve, repo: repoFull, product_purl: a.purl,
+    status: 'under_investigation',
+    detail: `No upstream fix available for ${a.package} (${a.severity}).`,
+    created_at: now, updated_by: 'cli:vex-no-fix',
+  }));
+  const doc = toOpenVex(repoFull, entries, `https://ry-ops.dev/vex/${repoFull}/no-fix`, now);
+  const newBody = JSON.stringify(doc, null, 2) + '\n';
+  // stable signature (statements only) so a timestamp-only delta doesn't churn
+  const sig = (d) => JSON.stringify(d.statements);
+
+  const base = (await octokit.rest.repos.get({ owner: ro, repo: rn })).data.default_branch;
+
+  // skip if the doc already on the default branch matches (no change to make)
+  try {
+    const { data: f } = await octokit.rest.repos.getContent({ owner: ro, repo: rn, path: VEX_PATH, ref: base });
+    const cur = JSON.parse(Buffer.from(f.content, 'base64').toString('utf-8'));
+    if (sig(cur) === sig(doc)) { console.log(`  ${repoFull}: VEX doc already current — no PR`); return; }
+  } catch { /* doc doesn't exist yet */ }
+
+  // (re)create the branch at base
+  const baseSha = (await octokit.rest.git.getRef({ owner: ro, repo: rn, ref: `heads/${base}` })).data.object.sha;
+  try {
+    await octokit.rest.git.updateRef({ owner: ro, repo: rn, ref: `heads/${VEX_BRANCH}`, sha: baseSha, force: true });
+  } catch {
+    await octokit.rest.git.createRef({ owner: ro, repo: rn, ref: `refs/heads/${VEX_BRANCH}`, sha: baseSha });
+  }
+
+  // commit the doc on the branch
+  let fileSha;
+  try {
+    fileSha = (await octokit.rest.repos.getContent({ owner: ro, repo: rn, path: VEX_PATH, ref: VEX_BRANCH })).data.sha;
+  } catch { /* new file */ }
+  await octokit.rest.repos.createOrUpdateFileContents({
+    owner: ro, repo: rn, path: VEX_PATH, branch: VEX_BRANCH,
+    message: `security(vex): document ${alerts.length} dependency advisory(ies) with no upstream fix`,
+    content: Buffer.from(newBody).toString('base64'),
+    ...(fileSha ? { sha: fileSha } : {}),
+  });
+
+  // PR body (human-readable documentation)
+  const rows = alerts.map((a) => `| \`${a.cve}\` | ${a.package} | ${a.severity.toUpperCase()} | \`${a.purl}\` |`).join('\n');
+  const body = [
+    '## Dependencies with no upstream fix (OpenVEX)',
+    '',
+    `git-steer's daily scan found **${alerts.length}** open Dependabot alert(s) on this repo for which **no patched version is currently available**. They cannot be auto-remediated by a version bump, so they are documented here as OpenVEX \`under_investigation\` — visible and machine-consumable — rather than silently ignored.`,
+    '',
+    '| CVE / GHSA | Package | Severity | PURL |',
+    '|---|---|---|---|',
+    rows,
+    '',
+    `Artifact: \`${VEX_PATH}\` (OpenVEX 0.2.0). Regenerated each scan; entries clear automatically when an upstream fix lands. A maintainer should assess exploitability and promote each to \`not_affected\` (+justification) or \`affected\` (+action_statement).`,
+    '',
+    'Generated by [git-steer](https://github.com/ry-ops/git-steer) · ADR-004 C-004-003',
+  ].join('\n');
+
+  for (const [n, c] of [['security', 'd73a4a'], ['automated', 'bfd4f2'], ['vex', '5319e7']]) {
+    try { await octokit.rest.issues.createLabel({ owner: ro, repo: rn, name: n, color: c }); } catch { /* exists */ }
+  }
+
+  let pr = (await octokit.rest.pulls.list({ owner: ro, repo: rn, head: `${ro}:${VEX_BRANCH}`, state: 'open' })).data[0];
+  if (pr) {
+    await octokit.rest.pulls.update({ owner: ro, repo: rn, pull_number: pr.number, title: `security(vex): ${alerts.length} dependency advisory(ies) with no fix`, body });
+  } else {
+    pr = (await octokit.rest.pulls.create({ owner: ro, repo: rn, head: VEX_BRANCH, base, title: `security(vex): ${alerts.length} dependency advisory(ies) with no fix`, body })).data;
+  }
+  try { await octokit.rest.issues.addLabels({ owner: ro, repo: rn, issue_number: pr.number, labels: ['security', 'automated', 'vex'] }); } catch { /* */ }
+
+  // doc-only change -> merge directly; if branch protection blocks, hold for human
+  try {
+    await octokit.rest.pulls.merge({ owner: ro, repo: rn, pull_number: pr.number, merge_method: 'squash',
+      commit_title: `security(vex): document ${alerts.length} no-fix advisory(ies)` });
+    console.log(`  ${repoFull}: VEX doc PR #${pr.number} merged`);
+  } catch {
+    try {
+      await octokit.rest.issues.addLabels({ owner: ro, repo: rn, issue_number: pr.number, labels: ['needs-human-merge'] });
+    } catch { /* */ }
+    console.log(`  ${repoFull}: VEX doc PR #${pr.number} open (merge blocked by branch protection — needs human)`);
+  }
 }
+
+console.log('Publishing OpenVEX documentation PRs...');
+for (const [repoFull, alerts] of Object.entries(byRepo)) {
+  try { await upsertVexDocPr(repoFull, alerts); }
+  catch (e) { console.warn(`  ${repoFull}: VEX doc PR failed — ${e.message}`); }
+}
+
+// ── 7. Report ─────────────────────────────────────────────────────────
+console.log('');
 for (const [repoName, alerts] of Object.entries(byRepo)) {
   console.log(`${repoName}: ${alerts.length} no-fix alert(s)`);
   for (const a of alerts) console.log(`  [${a.severity.toUpperCase()}] ${a.package} (${a.cve}) → ${a.purl}`);
-  console.log('');
 }


### PR DESCRIPTION
## What & why

You asked: VEX is state, but a **PR still needs to be created** to identify the no-fix state and document that a dependency has no available fix — and `vex-no-fix.mjs` should run **autonomously**. This does both.

### Before
- No-fix alerts were only VEX'd `affected` after a 3-sweep ADR-006 hard-stop.
- `vex-no-fix.mjs` (which writes the honest `under_investigation` state) was **manual** — keytar-only auth, never in the heartbeat — and produced **no artifact in the target repo**.

### Now
`vex-no-fix.mjs`:
1. **Dual-auth** (`GH_TOKEN` in CI, keytar locally) → runs unattended.
2. Records OpenVEX `under_investigation` to `git-steer-state` (`_vex` + `vex.jsonl`) — unchanged.
3. **Opens/refreshes a documenting PR** in each affected repo committing an OpenVEX 0.2.0 doc at `.well-known/openvex/no-fix.openvex.json` — a visible, machine-consumable artifact stating no fix is available, plus a human-readable PR body table.
   - Doc-only → **merged directly** (no functional-integrity gate; nothing to build). If branch protection blocks, labeled `needs-human-merge`.
   - **Idempotent**: skips when the repo's doc already matches; entries clear automatically as upstream fixes land.
4. **Wired into the daily heartbeat** after the escalation sweep.

`under_investigation` is the honest automated state; a maintainer later promotes each to `not_affected` (+justification) or `affected` (+action_statement) via `vex_set`.

## Verified
- `toOpenVex` produces valid OpenVEX 0.2.0 (tested with real DriveIQ no-fix advisories: nltk, torch).
- Build clean, 42 tests pass, heartbeat + script syntax valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)