### PR TITLE
feat(security): per-package remediation so clean fixes auto-merge

### DIFF
--- a/.github/workflows/security-fix-worker.yml
+++ b/.github/workflows/security-fix-worker.yml
@@ -20,6 +20,11 @@ on:
         default: 'critical'
         type: choice
         options: [critical, high, medium, low, all]
+      package_dir:
+        description: 'Scope the fix to ONE package/manifest dir (e.g. frontend, backend, "." for root). Empty = whole repo. Per-package scope lets the clean packages auto-merge while a broken one is held alone (ADR-007).'
+        required: false
+        default: ''
+        type: string
       dry_run:
         description: 'Preview only, no changes'
         required: false
@@ -90,6 +95,19 @@ jobs:
 
           FIXABLE=$(echo "$ALERTS" | jq --arg pat "$PATTERN" \
             '[.[] | select((.severity | test($pat)) and .fix_version != null)]')
+
+          # Per-package scope (ADR-007): keep only alerts whose manifest dir
+          # matches package_dir, so this PR touches exactly one buildable unit.
+          # The manifest dir is dirname(manifest_path), or "." at the repo root.
+          PKG_DIR="${{ inputs.package_dir }}"
+          if [ -n "$PKG_DIR" ]; then
+            FIXABLE=$(echo "$FIXABLE" | jq --arg d "$PKG_DIR" \
+              '[.[] | select(((.manifest | if test("/") then (split("/")[:-1] | join("/")) else "." end)) == $d)]')
+            SLUG=$(echo "$PKG_DIR" | sed 's#[/ ]#-#g; s#^\.$#root#')
+            echo "branch=security/fix-$SLUG" >> $GITHUB_OUTPUT
+          else
+            echo "branch=security/fix-$SEVERITY" >> $GITHUB_OUTPUT
+          fi
 
           echo "filtered<<EOF" >> $GITHUB_OUTPUT
           echo "$FIXABLE" >> $GITHUB_OUTPUT
@@ -223,7 +241,7 @@ jobs:
         env:
           FILTERED_JSON: ${{ steps.alerts.outputs.filtered }}
         run: |
-          BRANCH="security/fix-${{ inputs.severity }}"
+          BRANCH="${{ steps.alerts.outputs.branch }}"
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT
           git config user.name "git-steer[bot]"
           git config user.email "git-steer[bot]@users.noreply.github.com"
@@ -265,20 +283,20 @@ jobs:
         run: |
           REPO="${{ inputs.target_repo }}"; SEVERITY="${{ inputs.severity }}"
           COUNT="${{ steps.alerts.outputs.count }}"; BRANCH="${{ steps.commit.outputs.branch }}"
+          PKG_DIR="${{ inputs.package_dir }}"
+          SCOPE=${PKG_DIR:+ in \`$PKG_DIR\`}
+          TITLE="fix(security): Patch $COUNT vulnerabilities${PKG_DIR:+ in $PKG_DIR}"
           gh label create "security"     --color "d73a4a" --repo "$REPO" 2>/dev/null || true
           gh label create "dependencies" --color "0075ca" --repo "$REPO" 2>/dev/null || true
           gh label create "automated"    --color "bfd4f2" --repo "$REPO" 2>/dev/null || true
-          case $SEVERITY in critical) C="b60205";; high) C="ff9800";; medium) C="fbca04";; *) C="0e8a16";; esac
-          gh label create "severity:$SEVERITY" --color "$C" --repo "$REPO" 2>/dev/null || true
           EXISTING=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING" ]; then
-            gh pr edit "$EXISTING" --repo "$REPO" \
-              --title "fix(security): Patch $COUNT $SEVERITY+ vulnerabilities" --body-file /tmp/pr_body.md >/dev/null
+            gh pr edit "$EXISTING" --repo "$REPO" --title "$TITLE" --body-file /tmp/pr_body.md >/dev/null
             PR_NUM="$EXISTING"
           else
-            PR_URL=$(gh pr create --title "fix(security): Patch $COUNT $SEVERITY+ vulnerabilities" \
+            PR_URL=$(gh pr create --title "$TITLE" \
               --body-file /tmp/pr_body.md --head "$BRANCH" \
-              --label "security,dependencies,automated,severity:$SEVERITY" --repo "$REPO")
+              --label "security,dependencies,automated" --repo "$REPO")
             PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
           fi
           echo "number=$PR_NUM" >> $GITHUB_OUTPUT
@@ -334,7 +352,7 @@ jobs:
         run: |
           REPO="${{ inputs.target_repo }}"; PR_NUM="${{ needs.fix.outputs.pr_number }}"
           RESP=$(gh api "repos/$REPO/pulls/$PR_NUM/merge" -X PUT -f merge_method=squash \
-            -f commit_title="fix(security): Patch ${{ needs.fix.outputs.count }} ${{ inputs.severity }}+ vulnerabilities" \
+            -f commit_title="fix(security): Patch ${{ needs.fix.outputs.count }} vulnerabilities${{ inputs.package_dir && format(' in {0}', inputs.package_dir) || '' }}" \
             -f commit_message="Auto-merged by git-steer (ADR-005 verdict: GO)." 2>&1) || true
           if [ "$(echo "$RESP" | jq -r '.merged // false' 2>/dev/null)" = "true" ]; then
             echo "PR #$PR_NUM merged (GO)."

--- a/scripts/escalate-remediate.mjs
+++ b/scripts/escalate-remediate.mjs
@@ -38,7 +38,6 @@ if (!target || !REPO_RE.test(target) || target.split('/').some((s) => DANGEROUS.
 const [tOwner, tRepo] = target.split('/');
 const tIdx = process.argv.indexOf('--threshold');
 const THRESHOLD = tIdx >= 0 ? Number(process.argv[tIdx + 1]) : 3;
-const LADDER = ['critical', 'high', 'medium', 'low'];
 const WORKER = 'security-fix-worker.yml';
 const STEER = { owner: 'ry-ops', repo: 'git-steer' };
 const STATE_REPO = 'git-steer-state';
@@ -58,53 +57,71 @@ if (process.env.GH_TOKEN) {
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-// ── dispatch one rung and wait for its run to finish ──────────────────
-async function runRung(sev) {
-  const branch = `security/fix-${sev}`;
+const slug = (d) => d.replace(/[/ ]/g, '-').replace(/^\.$/, 'root');
+const manifestDir = (m) => (m && m.includes('/') ? m.split('/').slice(0, -1).join('/') : '.');
+
+// ── discover the buildable units (package dirs) with a fixable alert ───
+async function discoverPackages() {
+  const alerts = await octokit.paginate('GET /repos/{owner}/{repo}/dependabot/alerts', {
+    owner: tOwner, repo: tRepo, state: 'open', per_page: 100,
+  });
+  const dirs = new Set();
+  for (const a of alerts) {
+    if (!a.security_vulnerability?.first_patched_version?.identifier) continue; // no-fix → vex-no-fix
+    dirs.add(manifestDir(a.dependency?.manifest_path || ''));
+  }
+  return [...dirs];
+}
+
+// ── dispatch ONE package, wait for its run, report held / merged ──────
+// ADR-007: per-package scope. Each package is gated and auto-merged on its own,
+// so the clean packages land without a human and only a genuinely-broken one is
+// held — instead of one bad package holding the whole repo's fixes hostage.
+async function runPackage(pkgDir) {
+  const branch = `security/fix-${slug(pkgDir)}`;
   const before = (await octokit.rest.actions.listWorkflowRuns({ ...STEER, workflow_id: WORKER, per_page: 1 }))
     .data.workflow_runs[0]?.id ?? 0;
 
   await octokit.rest.actions.createWorkflowDispatch({
     ...STEER, workflow_id: WORKER, ref: 'main',
-    inputs: { target_repo: target, severity: sev, dry_run: 'false' },
+    inputs: { target_repo: target, severity: 'all', package_dir: pkgDir, dry_run: 'false' },
   });
 
-  // wait for the new run to appear + complete
   let run = null;
-  for (let i = 0; i < 60; i++) {
+  for (let i = 0; i < 90; i++) {
     await sleep(8000);
-    const runs = (await octokit.rest.actions.listWorkflowRuns({ ...STEER, workflow_id: WORKER, per_page: 5 })).data.workflow_runs;
+    const runs = (await octokit.rest.actions.listWorkflowRuns({ ...STEER, workflow_id: WORKER, per_page: 8 })).data.workflow_runs;
     run = runs.find((r) => r.id > before);
     if (run && run.status === 'completed') break;
   }
-  if (!run) return { sev, outcome: 'error', detail: 'no run observed' };
+  if (!run) return { sev: pkgDir, outcome: 'error', detail: 'no run observed' };
 
-  // outcome: open held PR on this scope's branch? else merged / no-change
   const open = (await octokit.rest.pulls.list({ owner: tOwner, repo: tRepo, head: `${tOwner}:${branch}`, state: 'open' })).data;
   if (open.length) {
-    const labels = open[0].labels.map((l) => l.name);
     let verdict = 'held';
     try {
       const comments = (await octokit.rest.issues.listComments({ owner: tOwner, repo: tRepo, issue_number: open[0].number })).data;
       const gc = [...comments].reverse().find((c) => /Functional-integrity gate/.test(c.body));
       verdict = gc?.body.match(/gate: ([A-Z-]+)/)?.[1] ?? 'held';
     } catch { /* */ }
-    return { sev, outcome: 'held', verdict, pr: open[0].number, labels };
+    return { sev: pkgDir, outcome: 'held', verdict, pr: open[0].number };
   }
-  return { sev, outcome: run.conclusion === 'success' ? 'merged_or_nochange' : 'error', detail: run.conclusion };
+  return { sev: pkgDir, outcome: run.conclusion === 'success' ? 'merged_or_nochange' : 'error', detail: run.conclusion };
 }
 
-// ── run the ladder ────────────────────────────────────────────────────
-console.log(`\n=== ADR-006 escalation: ${target} (hard-stop threshold ${THRESHOLD} sweeps) ===\n`);
+// ── sweep EVERY package (no early stop) ───────────────────────────────
+console.log(`\n=== ADR-006/007 per-package sweep: ${target} (hard-stop threshold ${THRESHOLD} sweeps) ===\n`);
+const packages = await discoverPackages();
+console.log(`  packages with a fixable alert: ${packages.length ? packages.join(', ') : '(none)'}\n`);
 let floor = null;
 const trail = [];
-for (const sev of LADDER) {
-  process.stdout.write(`  rung ${sev}... `);
-  const r = await runRung(sev);
+for (const pkgDir of packages) {
+  process.stdout.write(`  package ${pkgDir}... `);
+  const r = await runPackage(pkgDir);
   trail.push(r);
   console.log(r.outcome === 'held' ? `HELD (${r.verdict}) PR#${r.pr}` : r.outcome);
-  if (r.outcome === 'held') { floor = r; break; }
-  if (r.outcome === 'error') { floor = r; break; }
+  // the repo's residual "floor" is the first package that stayed held/errored
+  if (!floor && (r.outcome === 'held' || r.outcome === 'error')) floor = r;
 }
 
 // ── genuine-clear check: a no-op ladder with deps still open is NOT cleared ──


### PR DESCRIPTION
## Problem

The worker bundled **all fixes into one severity-scoped PR** across every package, and the gate rolled up to a single verdict (any package FAIL → whole PR NO-GO). On DriveIQ that meant **one broken package (`docker-extension/ui`) held all 66 fixes hostage** — including ~60 that build clean. Nothing auto-merged, which is the opposite of the autonomous behavior intended.

## Fix — per-package scope

Remediation is now scoped to one buildable unit at a time:

- **`security-fix-worker.yml`** gains a `package_dir` input: filters alerts to that manifest dir (`dirname(manifest_path)`, `.` at root), branches `security/fix-<slug>`, and fixes only that package. Empty `package_dir` = whole-repo (backward compatible). PR title/merge reflect the scope.
- **`escalate-remediate.mjs`** replaces the per-severity ladder with a **per-package sweep**: discovers each manifest dir with a fixable alert and dispatches the worker once per package (`severity=all`), processing **all** of them with no early stop. Each package is independently gated and **auto-merged on its own**.

## Outcome

On DriveIQ: `frontend` + `backend` fixes **auto-merge with no human**; only `docker-extension/ui` (genuine build break) is held — and it already says why (gate-observability fix #82). The ADR-006 hard-stop persistence now tracks the first package that stays held as the repo's residual.

Verified: manifest→package grouping correct (frontend, backend [requirements.txt + uv.lock], docker-extension/ui, root each route to their own branch); build clean, 42 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)