### PR TITLE
fix(security): scope the gate to the package being changed

### DIFF
--- a/.github/workflows/security-fix-worker.yml
+++ b/.github/workflows/security-fix-worker.yml
@@ -320,6 +320,7 @@ jobs:
       target_repo: ${{ inputs.target_repo }}
       ref: ${{ needs.fix.outputs.branch }}
       pr_number: ${{ needs.fix.outputs.pr_number }}
+      scope: ${{ inputs.package_dir }}   # gate ONLY the package this PR changed
     secrets: inherit
 
   # ── disposition: GO auto-merges; anything else is held for a human ──────

--- a/.github/workflows/verify-functional-form.yml
+++ b/.github/workflows/verify-functional-form.yml
@@ -17,6 +17,7 @@ on:
       pr_number:   { required: false, type: string, default: '' }
       bump_from:   { required: false, type: string, default: '' }  # SURFACE: old version
       bump_to:     { required: false, type: string, default: '' }  # SURFACE: new version
+      scope:       { required: false, type: string, default: '' }  # gate ONLY this package dir
     outputs:
       verdict:
         value: ${{ jobs.verify.outputs.verdict }}
@@ -31,6 +32,7 @@ on:
       pr_number:   { required: false, type: string, default: '' }
       bump_from:   { required: false, type: string, default: '' }
       bump_to:     { required: false, type: string, default: '' }
+      scope:       { required: false, type: string, default: '' }
 
 permissions:
   contents: read
@@ -90,7 +92,8 @@ jobs:
         id: gate
         run: |
           node gitsteer/scripts/gate/run-gate.mjs target \
-            --from "${{ inputs.bump_from }}" --to "${{ inputs.bump_to }}"
+            --from "${{ inputs.bump_from }}" --to "${{ inputs.bump_to }}" \
+            --scope "${{ inputs.scope }}"
 
       # ── Verdict provenance to git-steer-state (C-005-006 / ADR-007 Move C) ──
       - name: Generate token (state repo)

--- a/scopem/backend/package-lock.json
+++ b/scopem/backend/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "be",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "be"
+    }
+  }
+}

--- a/scopem/backend/package.json
+++ b/scopem/backend/package.json
@@ -1,0 +1,1 @@
+{"name":"be","scripts":{"build":"node -e \"process.exit(1)\""},"dependencies":{}}

--- a/scopem/frontend/package-lock.json
+++ b/scopem/frontend/package-lock.json
@@ -1,0 +1,10 @@
+{
+  "name": "fe",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fe"
+    }
+  }
+}

--- a/scopem/frontend/package.json
+++ b/scopem/frontend/package.json
@@ -1,0 +1,1 @@
+{"name":"fe","scripts":{"build":"node -e \"process.exit(0)\""},"dependencies":{}}

--- a/scripts/gate/run-gate.mjs
+++ b/scripts/gate/run-gate.mjs
@@ -189,8 +189,16 @@ function main() {
   const toIdx = args.indexOf('--to');
   const from = fromIdx >= 0 ? args[fromIdx + 1] : '';
   const to = toIdx >= 0 ? args[toIdx + 1] : '';
+  // --scope <dir>: gate ONLY the package at this manifest dir (ADR-007
+  // per-package). Without it, an unrelated package's pre-existing build break
+  // would hold a scoped fix that never touched it.
+  const scopeIdx = args.indexOf('--scope');
+  const scope = scopeIdx >= 0 ? (args[scopeIdx + 1] || '') : '';
 
-  const pkgs = discover(target);
+  let pkgs = discover(target);
+  if (scope) {
+    pkgs = pkgs.filter((p) => (relative(target, p.dir) || '.') === scope);
+  }
   const perPackage = pkgs.map((p) => {
     const r = gatePackage(p);
     return { package: relative(target, p.dir) || '.', ecosystem: p.ecosystem, ...r };


### PR DESCRIPTION
## The bug (found reviewing DriveIQ's open PRs)

Per-package remediation (#84) scoped the **fix** to one package but the **gate** still built **all** packages and rolled up to one verdict. So DriveIQ's `docker-extension/ui` — which has a *pre-existing* build break (`vite@7.3.6` vs `@vitejs/plugin-react` peer conflict) unrelated to any fix — held the **backend** and **frontend** PRs at NO-GO too. All three per-package PRs failed for the same unrelated reason; nothing could auto-merge.

## Fix

- `run-gate.mjs` gains `--scope <dir>`: filter discovered packages to the one at that manifest dir, so the gate verifies **only** the package the PR changed.
- `verify-functional-form.yml` takes a `scope` input → passes `--scope`.
- `security-fix-worker.yml` passes `package_dir` as `scope`.

Now backend's PR builds only backend (clean → **GO → auto-merge**), frontend builds only frontend (clean → **GO → auto-merge**), and **only** `docker-extension/ui` is held — its genuine break, with the reason on the PR.

## Verified

Synthetic monorepo (backend breaks): `--scope frontend` → **GO**, `--scope backend` → **NO-GO**. No cross-contamination. Build clean, 42 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)