### PR TITLE
feat(security): git-steer owns remediation — disable Dependabot auto-fixes

### DIFF
--- a/.github/workflows/heartbeat.yml
+++ b/.github/workflows/heartbeat.yml
@@ -95,17 +95,20 @@ jobs:
           while IFS= read -r repo; do
             [ -z "$repo" ] && continue
 
-            # Enable vulnerability alerts
+            # Enable vulnerability ALERTS — git-steer's OBSERVE source.
             gh api "repos/$repo/vulnerability-alerts" \
               -X PUT \
               --silent 2>/dev/null && echo "  $repo: vulnerability alerts enabled" \
               || echo "  $repo: vulnerability alerts already enabled or not accessible"
 
-            # Enable automated security fixes
+            # DISABLE automated-security-fixes (ADR-007 single-channel policy):
+            # git-steer's gated, per-package worker is the SOLE remediation path.
+            # Dependabot's own security-update PRs are UNGATED and duplicate the
+            # same CVE fixes, so we keep alerts but stop the competing PR stream.
             gh api "repos/$repo/automated-security-fixes" \
-              -X PUT \
-              --silent 2>/dev/null && echo "  $repo: automated security fixes enabled" \
-              || echo "  $repo: automated security fixes already enabled or not accessible"
+              -X DELETE \
+              --silent 2>/dev/null && echo "  $repo: automated security fixes DISABLED (git-steer owns remediation)" \
+              || echo "  $repo: automated security fixes already disabled or not accessible"
           done <<< "${{ steps.repos.outputs.repos }}"
 
       - name: Security scan


### PR DESCRIPTION
## Policy (you chose: git-steer owns remediation)

The heartbeat enabled Dependabot's `automated-security-fixes` on every managed repo — which is what made Dependabot open its **own ungated** security PRs for the same CVEs git-steer remediates through its **gated, per-package** worker. Two systems patching the same vulnerabilities; one verified, one not; both cluttering the PR list.

## Change

The "Enforce Dependabot" step now:
- **keeps** `vulnerability-alerts` enabled (git-steer's OBSERVE / detection source), and
- **disables** `automated-security-fixes` (`DELETE`) — git-steer's gated worker is the sole remediation channel.

Routine non-security version updates (`dependabot.yml`) are unaffected. Applies fleet-wide on the next heartbeat.

## Already done on DriveIQ
- `automated-security-fixes` disabled (verified `enabled=false`).
- 4 redundant Dependabot **security** PRs closed (#156 @babel/core, #145 starlette, #155 npm group, #143 uv group); 8 routine version-update PRs kept.
- Stale whole-repo PR #158 closed (superseded by per-package PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)