### PR TITLE
fix(security): differential gate + immediate VEX so every CVE resolves

### DIFF
--- a/.github/workflows/verify-functional-form.yml
+++ b/.github/workflows/verify-functional-form.yml
@@ -69,6 +69,17 @@ jobs:
           fetch-depth: 1
           path: target
 
+      # Baseline = the target repo's DEFAULT branch (no ref). The differential
+      # gate compares the fix branch against this so a failure that ALSO fails
+      # on base (pre-existing repo debt) doesn't hold a good security fix.
+      - name: Checkout base branch (baseline for the differential gate)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          repository: ${{ inputs.target_repo }}
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 1
+          path: base
+
       - name: Checkout git-steer (the gate runner)
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -93,7 +104,8 @@ jobs:
         run: |
           node gitsteer/scripts/gate/run-gate.mjs target \
             --from "${{ inputs.bump_from }}" --to "${{ inputs.bump_to }}" \
-            --scope "${{ inputs.scope }}"
+            --scope "${{ inputs.scope }}" \
+            --baseline base
 
       # ── Verdict provenance to git-steer-state (C-005-006 / ADR-007 Move C) ──
       - name: Generate token (state repo)

--- a/scripts/dispatch-fixes.mjs
+++ b/scripts/dispatch-fixes.mjs
@@ -19,7 +19,8 @@ const targetRepos = [
   'ry-ops/aiana',
   'ry-ops/ATSFlow',
   'ry-ops/DriveIQ',
-  'ry-ops/blog',
+  // ry-ops/blog removed: transferred to fabric-forge/blog and dropped from the
+  // managed fleet — remediation for it is intentionally skipped.
   'ry-ops/building-serverless-website-github-cloudflare',
   'ry-ops/getting-started-docker-containers',
   'ry-ops/building-rest-api-fastapi',

--- a/scripts/escalate-remediate.mjs
+++ b/scripts/escalate-remediate.mjs
@@ -190,35 +190,60 @@ await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
   sha: file.sha,
 });
 
-// ── enforce hard-stop at threshold: VEX affected + label PR/issue ─────
-if (hardStop) {
-  const num = floor.pr ?? trackingIssue;
-  const ref = floor.pr ? `PR#${floor.pr}` : trackingIssue ? `issue #${trackingIssue}` : 'no artifact';
-  if (num) { try { await octokit.rest.issues.addLabels({ owner: tOwner, repo: tRepo, issue_number: num, labels: ['escalation:hard-stop'] }); } catch { /* */ } }
+// ── terminal disposition: every CVE residual ends FIXED or VEX'd ──────
+// The ADR-004 contract is simple: if there's a fix, apply it; if there isn't,
+// VEX it until one exists. A held PR (genuine gate NO-GO) is a human's call.
+// But a NO-OP fall-out means the bump worker CANNOT produce a fix (transitive /
+// not directly bumpable) — that is exactly "no fix available", so it gets a VEX
+// `under_investigation` on the FIRST sweep, not after looping to the hard-stop.
+// At the hard-stop threshold the residual escalates to `affected` (human review).
+// The VEX key is stable per repo so the lifecycle under_investigation -> affected
+// -> fixed tracks one entry the dashboard can read.
+const RESIDUAL_CVE = `escalation/${target}#residual`;
+async function setResidualVex(status, actionStatement) {
   const entry = {
-    cve_id: `escalation/${target}#fix-${floor.sev}`,
+    cve_id: RESIDUAL_CVE,
     repo: target,
     product_purl: `pkg:github/${target}`,
-    status: 'affected',
-    action_statement: `Autonomous remediation exhausted the ADR-006 ladder for ${THRESHOLD}+ consecutive sweeps; floor=${floor.sev}, ${remaining} dep(s) remain (${floor.verdict}). Held for human review at ${ref}.`,
-    detail: `ADR-006 C-006-008 hard-stop.`,
+    status,
+    detail: `ADR-006 residual${floor ? `: floor ${floor.sev} (${floor.verdict ?? floor.detail})` : ' cleared'}`.slice(0, 480),
     created_at: now,
     updated_by: 'cli:escalate-remediate',
   };
-  if (!validateVexInput(entry)) {
-    const fresh = (await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', { owner: STEER.owner, repo: STATE_REPO, path: 'state/cache.json' })).data;
-    const c2 = JSON.parse(Buffer.from(fresh.content, 'base64').toString('utf-8'));
-    c2._vex = c2._vex ?? {};
-    c2._vex[vexId(target, entry.cve_id)] = entry;
-    await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
-      owner: STEER.owner, repo: STATE_REPO, path: 'state/cache.json',
-      message: `vex: hard-stop affected for ${target} (ADR-006 C-006-008)`,
-      content: Buffer.from(JSON.stringify(c2, null, 2)).toString('base64'),
-      sha: fresh.sha,
-    });
-    await appendJsonl(octokit, STEER.owner, STATE_REPO, 'state/vex.jsonl', [makeVexLedgerEntry(entry, null, 'cli:escalate-remediate', now)]);
-    console.log(`  VEX affected written + escalation:hard-stop on ${ref}`);
+  if (status === 'affected') entry.action_statement = actionStatement;
+  // validateVexInput returns an error string when INVALID, null when valid.
+  if (validateVexInput(entry)) return;
+  const fresh = (await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', { owner: STEER.owner, repo: STATE_REPO, path: 'state/cache.json' })).data;
+  const c2 = JSON.parse(Buffer.from(fresh.content, 'base64').toString('utf-8'));
+  c2._vex = c2._vex ?? {};
+  const key = vexId(target, RESIDUAL_CVE);
+  const prev = c2._vex[key]?.status ?? null;
+  if (prev === status) return;                              // idempotent — already in this state
+  if (status === 'fixed' && prev === null) return;          // nothing to lift; don't manufacture a record
+  c2._vex[key] = entry;
+  await octokit.request('PUT /repos/{owner}/{repo}/contents/{path}', {
+    owner: STEER.owner, repo: STATE_REPO, path: 'state/cache.json',
+    message: `vex: residual ${status} for ${target} (ADR-006)`,
+    content: Buffer.from(JSON.stringify(c2, null, 2)).toString('base64'),
+    sha: fresh.sha,
+  });
+  await appendJsonl(octokit, STEER.owner, STATE_REPO, 'state/vex.jsonl', [makeVexLedgerEntry(entry, prev, 'cli:escalate-remediate', now)]);
+  console.log(`  VEX residual ${prev ?? 'new'} -> ${status} for ${target}`);
+}
+
+if (floor) {
+  if (hardStop) {
+    const num = floor.pr ?? trackingIssue;
+    const ref = floor.pr ? `PR#${floor.pr}` : trackingIssue ? `issue #${trackingIssue}` : 'no artifact';
+    if (num) { try { await octokit.rest.issues.addLabels({ owner: tOwner, repo: tRepo, issue_number: num, labels: ['escalation:hard-stop'] }); } catch { /* */ } }
+    await setResidualVex('affected', `Autonomous remediation exhausted the ADR-006 ladder for ${THRESHOLD}+ consecutive sweeps; floor=${floor.sev}, ${remaining} dep(s) remain (${floor.verdict ?? floor.detail}). Held for human review at ${ref}.`);
+  } else if (!floor.pr) {
+    // residual the bump worker couldn't fix (no PR producible) → VEX now
+    await setResidualVex('under_investigation');
   }
+} else {
+  // genuinely cleared (0 deps remain) → lift any residual VEX to fixed
+  await setResidualVex('fixed');
 }
 
 console.log(`\n=== trail ===`);

--- a/scripts/gate/run-gate.mjs
+++ b/scripts/gate/run-gate.mjs
@@ -82,9 +82,14 @@ function gatePackage(pkg) {
 
   if (ecosystem === 'npm') {
     const pj = JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
-    // BUILD: deps resolve (lockfile coherent) + compiles if a build script exists
+    // BUILD: deps resolve (lockfile coherent) + compiles if a build script exists.
+    // Fallback ladder: npm ci -> npm install -> npm install --legacy-peer-deps.
+    // A peer-dependency conflict (ERESOLVE) is npm's resolver being strict, not
+    // the security bump being unsafe — so we retry the way a human would rather
+    // than failing BUILD and holding the fix forever (e.g. DriveIQ vite peer).
     const ci = run('npm ci', dir);
-    const inst = ci.ok ? ci : run('npm install --no-audit --no-fund', dir);
+    let inst = ci.ok ? ci : run('npm install --no-audit --no-fund', dir);
+    if (!inst.ok) inst = run('npm install --no-audit --no-fund --legacy-peer-deps', dir);
     if (!inst.ok) { build = 'FAIL'; errors.build = inst.tail; }
     else if (pj.scripts?.build) {
       const b = run('npm run build', dir);
@@ -155,6 +160,55 @@ function rollup(results, key) {
   return 'NOT_APPLICABLE';
 }
 
+// ── discover + gate a whole tree (optionally scoped to one package) ───
+function gateTree(root, scope) {
+  let pkgs = discover(root);
+  if (scope) pkgs = pkgs.filter((p) => (relative(root, p.dir) || '.') === scope);
+  return pkgs.map((p) => {
+    const r = gatePackage(p);
+    return { package: relative(root, p.dir) || '.', ecosystem: p.ecosystem, ...r };
+  });
+}
+
+function buildDims(perPackage, from, to) {
+  const dimKey = { BUILD: 'build', TEST: 'test', SMOKE: 'smoke' };
+  const dims = ['BUILD', 'TEST', 'SMOKE'].map((d) => {
+    const key = dimKey[d];
+    const dim = { dimension: d, result: rollup(perPackage, key) };
+    if (perPackage.some((p) => p[`${key}_preexisting`])) dim.preexisting = true;
+    return dim;
+  });
+  dims.push({ dimension: 'SURFACE', result: surfaceForBump(from, to) });
+  return dims;
+}
+
+// ── differential gate: neutralize failures that ALSO fail on the base ──
+// A security fix is only blocked for a dimension it REGRESSES (passed on the
+// base branch, fails on the fix branch). A dimension already red on base — a
+// missing test file, a broken monorepo import, a build that never worked — is
+// pre-existing repo debt, not the bump's fault, and must not hold the fix.
+// This is the line between "the fix breaks the build" and "the build was
+// already broken." Without it, any repo with a flaky/red main freezes forever.
+function applyBaseline(fixPkgs, basePkgs) {
+  const baseByPath = new Map(basePkgs.map((p) => [p.package, p]));
+  const notes = [];
+  for (const p of fixPkgs) {
+    const base = baseByPath.get(p.package);
+    for (const key of ['build', 'test', 'smoke']) {
+      // Neutralize ONLY if the base has this package and did NOT pass the
+      // dimension. If base passed it and the fix fails it, that's a genuine
+      // regression and stays a FAIL (legitimately held for a human).
+      if (p[key] === 'FAIL' && base && base[key] !== 'PASS') {
+        p[`${key}_preexisting`] = true;
+        if (p.errors && p.errors[key]) delete p.errors[key]; // no longer a hold reason
+        p[key] = 'NOT_APPLICABLE'; // neutral for rollup + verdict
+        notes.push(`\`${p.package}\` — ${key.toUpperCase()} fails on the base branch too; pre-existing, not counted as a regression.`);
+      }
+    }
+  }
+  return notes;
+}
+
 // ── SURFACE (mirrors surfaceForBump in src/core/verdict.ts) ───────────
 function surfaceForBump(from, to) {
   const parse = (v) => {
@@ -194,26 +248,42 @@ function main() {
   // would hold a scoped fix that never touched it.
   const scopeIdx = args.indexOf('--scope');
   const scope = scopeIdx >= 0 ? (args[scopeIdx + 1] || '') : '';
+  // --baseline <dir>: a checkout of the BASE branch, used to drop pre-existing
+  // failures so repo debt can't hold a good security fix (differential gate).
+  const baseIdx = args.indexOf('--baseline');
+  const baseline = baseIdx >= 0 ? (args[baseIdx + 1] || '') : '';
 
-  let pkgs = discover(target);
-  if (scope) {
-    pkgs = pkgs.filter((p) => (relative(target, p.dir) || '.') === scope);
+  const perPackage = gateTree(target, scope);
+  let dims = buildDims(perPackage, from, to);
+  let verdict = aggregateVerdict(dims);
+  let baselineNotes = [];
+
+  // Only pay for the baseline gate when the fix isn't already clean. A GO needs
+  // no baseline (nothing to excuse); a non-GO might be held purely by pre-existing
+  // breakage, so re-judge it against the base branch before holding for a human.
+  if (verdict !== 'GO' && baseline) {
+    const baseDir = resolve(baseline);
+    if (existsSync(baseDir) && statSync(baseDir).isDirectory()) {
+      const basePkgs = gateTree(baseDir, scope);
+      baselineNotes = applyBaseline(perPackage, basePkgs);
+      if (baselineNotes.length) {
+        dims = buildDims(perPackage, from, to);
+        verdict = aggregateVerdict(dims);
+      }
+    }
   }
-  const perPackage = pkgs.map((p) => {
-    const r = gatePackage(p);
-    return { package: relative(target, p.dir) || '.', ecosystem: p.ecosystem, ...r };
-  });
 
-  const dims = [
-    { dimension: 'BUILD', result: rollup(perPackage, 'build') },
-    { dimension: 'TEST', result: rollup(perPackage, 'test') },
-    { dimension: 'SMOKE', result: rollup(perPackage, 'smoke') },
-    { dimension: 'SURFACE', result: surfaceForBump(from, to) },
-  ];
-  const verdict = aggregateVerdict(dims);
-
-  const report = buildReport(verdict, perPackage);
-  const out = { verdict, dimensions: dims, packages: perPackage, packagesDiscovered: pkgs.length, report };
+  let report = buildReport(verdict, perPackage);
+  if (baselineNotes.length) {
+    const head = verdict === 'GO'
+      ? '**Differential gate — the security fix itself is clean; pre-existing failures were ignored:**'
+      : '**Differential gate — these pre-existing failures were ignored (not regressions):**';
+    report = [head, '', ...baselineNotes.map((n) => `- ${n}`), report ? '\n' + report : ''].join('\n').slice(0, 60000);
+  }
+  const out = {
+    verdict, dimensions: dims, packages: perPackage,
+    packagesDiscovered: perPackage.length, baselineApplied: baselineNotes.length > 0, report,
+  };
   console.log(JSON.stringify(out, null, 2));
 
   if (process.env.GITHUB_OUTPUT) {


### PR DESCRIPTION
## Why

git-steer stopped landing CVE fixes. Diagnosis: the automation was running fine, but the **ADR-005 functional-integrity gate was holding good security fixes for reasons unrelated to the bump**, so every repo with any pre-existing breakage froze after 3 NO-GO sweeps. This PR restores the simple contract:

> **If there's a fix, apply it. If there isn't, VEX it until one exists.**

### Evidence (from the frozen fleet)
| Repo | Fix itself | Why it was wrongly held |
|---|---|---|
| commit-relay | **BUILD=PASS** | `npm test` → test file missing *on main too*; SMOKE → broken monorepo import *on main too* |
| DriveIQ | valid bump | gate's `npm install` hit a vite peer-dep conflict; never retried `--legacy-peer-deps` |
| qdrant-fabric, linux | transitive dep | bump worker is a no-op → looped 3× instead of VEX'ing |

## What changed (all in the shared remediation path — every caller benefits)

1. **Differential gate** (`run-gate.mjs` + `verify-functional-form.yml`): gate the **base branch** too; a dimension is only NO-GO if it **regresses** (passed on base, fails on fix). Pre-existing failures are neutralized and reported as such. Genuine regressions still produce NO-GO (verified).
2. **`--legacy-peer-deps` fallback** in the gate's npm install ladder (`npm ci` → `npm install` → `npm install --legacy-peer-deps`).
3. **Terminal disposition** (`escalate-remediate.mjs`): a no-op residual gets VEX `under_investigation` on the **first** sweep; escalates to `affected` at the hard-stop threshold; lifts to `fixed` on clear. Nothing sits in limbo.
4. Drop stale `ry-ops/blog` from `dispatch-fixes.mjs` (transferred to `fabric-forge/blog`, out of the managed fleet).

## Testing
- `npm run build` clean; `npm test` 42 passed / 3 skipped.
- Synthetic gate checks: base-also-fails → **GO** (excused); base-passes-fix-fails → **NO-GO** (regression held).

🤖 Generated with [Claude Code](https://claude.com/claude-code)